### PR TITLE
Handle zero-row query results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R: c(
       person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
              comment = c(ORCID = "0000-0001-5670-2640")),
       person("Edward", "Visel", email = "edward.visel@gmail.com", role = "ctb"),
-      person("Andy", "Hine", email = "andyyhine@gmail.com", role = "ctb")
+      person("Andy", "Hine", email = "andyyhine@gmail.com", role = "ctb"),
+      person("Scott", "Came", email = "scottcame10@gmail.com", role = "ctb")
     )
 Description: 'Apache Drill' is a low-latency distributed query engine designed to enable 
     data exploration and 'analytics' on both relational and non-relational 'datastores', 
@@ -35,4 +36,4 @@ Imports:
 Suggests:
     testthat (>= 1.0.2),
     covr (>= 3.0.0)
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1

--- a/R/query.r
+++ b/R/query.r
@@ -77,5 +77,11 @@ drill_query <- function(drill_con, query, uplift=TRUE, .progress=interactive()) 
 #' @references \href{https://drill.apache.org/docs/}{Drill documentation}
 #' @export
 drill_uplift <- function(query_result) {
-  dplyr::tbl_df(readr::type_convert(query_result$rows))
+  # this could be handled better by constructing a zero-row tibble from the column names and type metadata returned by the
+  # REST API.  For now though this avoids the error thrown by tbl_df in the zero-row case.
+  ret <- tibble::tibble()
+  if (length(query_result$rows) != 0) {
+    ret <- dplyr::tbl_df(readr::type_convert(query_result$rows))
+  }
+  ret
 }

--- a/R/schemas.R
+++ b/R/schemas.R
@@ -1,11 +1,13 @@
 #' Returns a list of available schemas.
 #'
 #' @param drill_con drill server connection object setup by \code{drill_connection()}
+#' @param .progress if \code{TRUE} (default if in an interactive session) then ask
+#'                  \code{httr::POST} to display a progress bar
 #' @references \href{https://drill.apache.org/docs/}{Drill documentation}
 #' @family Dill direct REST API Interface
 #' @export
-drill_show_schemas <- function(drill_con) {
-  drill_query(drill_con, "SHOW SCHEMAS")
+drill_show_schemas <- function(drill_con, .progress=interactive()) {
+  drill_query(drill_con, "SHOW SCHEMAS", .progress = .progress)
 }
 
 #' Change to a particular schema.
@@ -13,12 +15,14 @@ drill_show_schemas <- function(drill_con) {
 #' @param drill_con drill server connection object setup by \code{drill_connection()}
 #' @param schema_name A unique name for a Drill schema. A schema in Drill is a configured
 #'                   storage plugin, such as hive, or a storage plugin and workspace.
+#' @param .progress if \code{TRUE} (default if in an interactive session) then ask
+#'                  \code{httr::POST} to display a progress bar
 #' @references \href{https://drill.apache.org/docs/}{Drill documentation}
 #' @family Dill direct REST API Interface
 #' @export
-drill_use <- function(drill_con, schema_name) {
+drill_use <- function(drill_con, schema_name, .progress=interactive()) {
   query <- sprintf("USE `%s`", schema_name)
-  out <- drill_query(drill_con, query)
+  out <- drill_query(drill_con, query, .progress = .progress)
   if (!("errorMessage" %in% names(out))) message(out)
   invisible(out)
 }
@@ -27,6 +31,8 @@ drill_use <- function(drill_con, schema_name) {
 #'
 #' @param drill_con drill server connection object setup by \code{drill_connection()}
 #' @param schema_spec properly quoted "filesystem.directory_name" reference path
+#' @param .progress if \code{TRUE} (default if in an interactive session) then ask
+#'                  \code{httr::POST} to display a progress bar
 #' @export
 #' @references \href{https://drill.apache.org/docs/}{Drill documentation}
 #' @family Dill direct REST API Interface
@@ -34,8 +40,8 @@ drill_use <- function(drill_con, schema_name) {
 #' try({
 #' drill_connection() %>% drill_show_files("dfs.tmp")
 #' }, silent=TRUE)
-drill_show_files <- function(drill_con, schema_spec) {
+drill_show_files <- function(drill_con, schema_spec, .progress=interactive()) {
   query <- sprintf("SHOW FILES IN %s", schema_spec)
-  drill_query(drill_con, query, uplift=TRUE) %>%
+  drill_query(drill_con, query, uplift=TRUE, .progress = .progress) %>%
     dplyr::select(name, isDirectory, permissions, dplyr::everything())
 }

--- a/man/Drill.Rd
+++ b/man/Drill.Rd
@@ -8,8 +8,8 @@
 \usage{
 Drill()
 
-\S4method{dbConnect}{DrillDriver}(drv, host = "localhost", port = 8047L,
-  ssl = FALSE, username = NULL, password = NULL, ...)
+\S4method{dbConnect}{DrillDriver}(drv, host = "localhost",
+  port = 8047L, ssl = FALSE, username = NULL, password = NULL, ...)
 }
 \arguments{
 \item{drv}{An object created by \code{Drill()}}

--- a/man/drill_show_files.Rd
+++ b/man/drill_show_files.Rd
@@ -4,12 +4,15 @@
 \alias{drill_show_files}
 \title{Show files in a file system schema.}
 \usage{
-drill_show_files(drill_con, schema_spec)
+drill_show_files(drill_con, schema_spec, .progress = interactive())
 }
 \arguments{
 \item{drill_con}{drill server connection object setup by \code{drill_connection()}}
 
 \item{schema_spec}{properly quoted "filesystem.directory_name" reference path}
+
+\item{.progress}{if \code{TRUE} (default if in an interactive session) then ask
+\code{httr::POST} to display a progress bar}
 }
 \description{
 Show files in a file system schema.

--- a/man/drill_show_schemas.Rd
+++ b/man/drill_show_schemas.Rd
@@ -4,10 +4,13 @@
 \alias{drill_show_schemas}
 \title{Returns a list of available schemas.}
 \usage{
-drill_show_schemas(drill_con)
+drill_show_schemas(drill_con, .progress = interactive())
 }
 \arguments{
 \item{drill_con}{drill server connection object setup by \code{drill_connection()}}
+
+\item{.progress}{if \code{TRUE} (default if in an interactive session) then ask
+\code{httr::POST} to display a progress bar}
 }
 \description{
 Returns a list of available schemas.

--- a/man/drill_use.Rd
+++ b/man/drill_use.Rd
@@ -4,13 +4,16 @@
 \alias{drill_use}
 \title{Change to a particular schema.}
 \usage{
-drill_use(drill_con, schema_name)
+drill_use(drill_con, schema_name, .progress = interactive())
 }
 \arguments{
 \item{drill_con}{drill server connection object setup by \code{drill_connection()}}
 
 \item{schema_name}{A unique name for a Drill schema. A schema in Drill is a configured
 storage plugin, such as hive, or a storage plugin and workspace.}
+
+\item{.progress}{if \code{TRUE} (default if in an interactive session) then ask
+\code{httr::POST} to display a progress bar}
 }
 \description{
 Change to a particular schema.

--- a/tests/testthat/test-sergeant.R
+++ b/tests/testthat/test-sergeant.R
@@ -51,3 +51,15 @@ test_that("REST API works", {
 
 
 })
+
+test_that("handle empty query results", {
+
+  testthat::skip_on_cran()
+
+  dc <- drill_connection(test_host)
+
+  test_rest <- drill_query(dc, "SELECT * FROM cp.`employee.json` where employee_id=-1")
+
+  expect_that(test_rest, is_a("data.frame"))
+
+})


### PR DESCRIPTION
Currently if you do `drill_query()` and the underlying query has zero rows, an error is raised underneath `dplyr::tbl_df()`. This PR exposes the scenario with a test and provides a simple, initial fix.