### PR TITLE
Fix SQL translation for `lag()` and `lead()` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # sergeant 0.9.1
 
+- Fixed SQL translation bug for `lag()` and `lead()` (@alistaire47)
 - Fixed identifier quoting issue #44 by @alistaire47
 - Fixed `RETRY` bug in `drill_query` (directg REST API)
 

--- a/R/dplyr.r
+++ b/R/dplyr.r
@@ -263,6 +263,20 @@ sql_translate_env.DrillConnection <- function(con) {
       .parent = dbplyr::base_win,
       n = function() { dbplyr::win_over(dbplyr::sql("count(*)"),
                                         partition = dbplyr::win_current_group()) },
+      lag = function(x, n = 1L, default = NA, order_by = NULL, ...) {
+        dbplyr::win_over(
+          dbplyr::sql_call2("lag", x, n),
+          partition = dbplyr::win_current_group(),
+          order = if (is.null(order_by)) dbplyr::win_current_order() else order_by
+        )
+      },
+      lead = function(x, n = 1L, default = NA, order_by = NULL, ...) {
+        dbplyr::win_over(
+          dbplyr::sql_call2("lead", x, n),
+          partition = dbplyr::win_current_group(),
+          order = if (is.null(order_by)) dbplyr::win_current_order() else order_by
+        )
+      },
       cor = dbplyr::win_recycled("corr"),
       cov = dbplyr::win_recycled("covar_samp"),
       sd =  dbplyr::win_recycled("stddev_samp"),


### PR DESCRIPTION
Hi!

Just a quick PR so Drill doesn't error out when using `lead()` or `lag()` with dbplyr SQL translation. Before this, the value for `default` (`NA` by default) would get passed in as a third argument (e.g. `LAG(variable1, 1, NA)`) which causes Drill to throw an error that refers users to [this Jira ticket](https://issues.apache.org/jira/browse/DRILL-3596).

This implementation does pass through the value for `n`, which is `1L` by default. Drill doesn't currently support any other value besides 1, but this implementation works and will be forwards-compatible if the limitation gets lifted in the future.